### PR TITLE
Add setter for `Basis.four_element_traces`

### DIFF
--- a/filter_functions/basis.py
+++ b/filter_functions/basis.py
@@ -368,6 +368,10 @@ class Basis(ndarray):
 
         return self._four_element_traces
 
+    @four_element_traces.setter
+    def four_element_traces(self, traces):
+        self._four_element_traces = traces
+
     def normalize(self) -> None:
         """Normalize the basis in-place"""
         if self.ndim == 2:

--- a/tests/test_basis.py
+++ b/tests/test_basis.py
@@ -111,10 +111,14 @@ class BasisTest(testutil.TestCase):
 
             if base.d < 8:
                 # Test very resource intense
+                ref = np.einsum('iab,jbc,kcd,lda', *(base,)*4)
                 self.assertArrayAlmostEqual(base.four_element_traces.todense(),
-                                            np.einsum('iab,jbc,kcd,lda',
-                                                      *(base,)*4),
-                                            atol=1e-16)
+                                            ref, atol=1e-16)
+
+                # Test setter
+                base._four_element_traces = None
+                base.four_element_traces = ref
+                self.assertArrayEqual(base.four_element_traces, ref)
 
             base._print_checks()
 


### PR DESCRIPTION
Since this is a costly quantity to compute, we want to allow setting it for new instances with a precomputed value.