### PR TITLE
Make vscode's interactive terminal work

### DIFF
--- a/filter_functions/util.py
+++ b/filter_functions/util.py
@@ -147,8 +147,11 @@ try:
                                     params={'token': ss.get('token', '')})
             for nn in json.loads(response.text):
                 if nn['kernel']['id'] == kernel_id:
-                    relative_path = nn['notebook']['path']
-                    return os.path.join(ss['notebook_dir'], relative_path)
+                    try:
+                        relative_path = nn['notebook']['path']
+                        return os.path.join(ss['notebook_dir'], relative_path)
+                    except KeyError:
+                        return ''
 
         return ''
 


### PR DESCRIPTION
The interactive terminal is running a jupyter kernel but is not registered as a notebook, which is why the following lines throws an exception when importing the package:
https://github.com/qutech/filter_functions/blob/7fddd61235858b56a9a3b9e572f23ba8d455bfcd/filter_functions/util.py#L148-L150

Catching the error and returning an empty string to tell the module that `tqdm_notebook` is not available should resolve this.