### PR TITLE
Feature/generalized filter functions

### DIFF
--- a/doc/source/examples/advanced_concatenation.ipynb
+++ b/doc/source/examples/advanced_concatenation.ipynb
@@ -142,7 +142,7 @@
    "metadata": {},
    "source": [
     "## Calculating the pulse correlation filter functions\n",
-    "Finally, we can set up the `PulseSequence`s and compute the filter functions. For the Hadamard pulse, we will set an additional flag during concatenation to calculate the 'pulse correlation filter function' which captures the cross-correlational effects of individual pulses on the total pulse sequence's susceptibility to noise."
+    "Finally, we can set up the `PulseSequence`s and compute the (fidelity) filter functions. For the Hadamard pulse, we will set an additional flag during concatenation to calculate the 'pulse correlation filter function' which captures the cross-correlational effects of individual pulses on the total pulse sequence's susceptibility to noise."
    ]
   },
   {
@@ -244,7 +244,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.1"
+   "version": "3.8.3"
   }
  },
  "nbformat": 4,

--- a/doc/source/examples/extending_pulses.ipynb
+++ b/doc/source/examples/extending_pulses.ipynb
@@ -230,7 +230,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.1"
+   "version": "3.8.3"
   }
  },
  "nbformat": 4,

--- a/doc/source/examples/getting_started.ipynb
+++ b/doc/source/examples/getting_started.ipynb
@@ -20,6 +20,8 @@
     "\n",
     "Therefore, the decoherence can be very intuitively understood and studied by examining the filter function in the frequency domain -- if it is large, the system will be very susceptible to noise at that frequency, while if it is small, noise of that frequency will be 'filtered out'. In this regard, the filter function is very similar to the transfer function of electrical circuits.\n",
     "\n",
+    "Other filter functions than the one *fidelity* filter function above which describes phase coherence may be defined in a similar way and obtained as linear combinations of *generalized* filter functions. These functions are defined with respect to an orthonormal operator basis $\\lbrace C_k\\rbrace_{k=0}^{d^2-1}$ and the fidelity filter function, for example, may be obtained from them by tracing out the basis indices, $F(\\omega) = \\mathrm{tr}(F_{kl}(\\omega))$.\n",
+    "\n",
     "### The `PulseSequence` class\n",
     "The central object of this package is the `PulseSequence` class. It is used to represent the control operation implementing a certain Hamiltonian ${H}_c$ and the sensitivities of the noise afflicting the system. More concisely, the total Hamiltonian of the system is modelled as\n",
     "\n",
@@ -46,7 +48,7 @@
    "metadata": {},
    "source": [
     "## A simple example\n",
-    "To illustrate the instantiation syntax, we would like to compute the filter function for a Free Induction Decay (FID) experiment, which is given by [[Cywiński et al. (2008)]]\n",
+    "To illustrate the instantiation syntax, we would like to compute the fidelity filter function for a Free Induction Decay (FID) experiment, which is given by [[Cywiński et al. (2008)]]\n",
     "\n",
     "$$\n",
     "    F(\\omega\\tau) = \\frac{2\\sin^2\\frac{\\omega\\tau}{2}}{\\omega^2}\n",
@@ -166,6 +168,27 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### Generalized filter functions\n",
+    "As mentioned above, we can of course also compute the fidelity filter function from the generalized filter functions. These may be obtained by specifying a corresponding flag when calling `PulseSequence.get_filter_function()`. We can verify that the fidelity filter function above is calculated correctly by taking the trace over the basis elements of the generalized filter functions. By convention, the first two axes of this quantity correspond to the noise operators $B_\\alpha,B_\\beta$, and the third and fourth correspond to the basis elements $C_k,C_l$."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "F_fid = FID.get_filter_function(omega, which='fidelity')\n",
+    "F_gen = FID.get_filter_function(omega, which='generalized')\n",
+    "\n",
+    "print(F_fid.shape, F_gen.shape)\n",
+    "print(np.allclose(F_fid, F_gen.trace(axis1=2, axis2=3)))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## A slightly more involved example\n",
     "As a slightly more involved example, we implement a Spin Echo (SE) pulse, that is, a $\\pi$-pulse sandwiched between two periods of free evolution. Here, the analytical solution in the 'Bang-Bang' limit ($\\delta$-shaped pulses) is given by\n",
     "\n",
@@ -272,7 +295,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.1"
+   "version": "3.8.3"
   }
  },
  "nbformat": 4,

--- a/filter_functions/plotting.py
+++ b/filter_functions/plotting.py
@@ -293,8 +293,8 @@ def plot_filter_function(pulse: 'PulseSequence',
                          gridspec_kw: Optional[dict] = None,
                          **figure_kw) -> FigureAxesLegend:
     r"""
-    Plot the filter function(s) of the given PulseSequence for positive
-    frequencies. As of now only the diagonal elements of
+    Plot the fidelity filter function(s) of the given PulseSequence for
+    positive frequencies. As of now only the diagonal elements of
     :math:`F_{\alpha\beta}` are implemented, i.e. the filter functions
     corresponding to uncorrelated noise sources.
 
@@ -412,8 +412,9 @@ def plot_pulse_correlation_filter_function(
         gridspec_kw: Optional[dict] = None,
         **figure_kw) -> FigureAxesLegend:
     r"""
-    Plot the pulse correlation filter functions of the given PulseSequence if
-    they were computed during concatenation for positive frequencies.
+    Plot the fidelity pulse correlation filter functions of the given
+    PulseSequence if they were computed during concatenation for positive
+    frequencies.
 
     Returns a figure with *n* by *n* subplots where *n* is the number of pulses
     that were concatenated. As of now only the diagonal elements of

--- a/filter_functions/pulse_sequence.py
+++ b/filter_functions/pulse_sequence.py
@@ -396,9 +396,12 @@ class PulseSequence:
                    'total phases': '_total_phases',
                    'filter function': '_F',
                    'fidelity filter function': '_F',
+                   'generalized filter function': '_F_kl',
                    'pulse correlation filter function': '_F_pc',
                    'fidelity pulse correlation filter function': '_F_pc',
-                   'control matrix': '_R'}
+                   'generalized pulse correlation filter function': '_F_pc_kl',
+                   'control matrix': '_R',
+                   'pulse correlation control matrix': '_R_pc'}
 
         alias = attr.lower().replace('_', ' ')
         if alias in aliases:

--- a/filter_functions/pulse_sequence.py
+++ b/filter_functions/pulse_sequence.py
@@ -696,7 +696,7 @@ class PulseSequence:
 
         if self.is_cached('R_pc'):
             F_pc = numeric.calculate_pulse_correlation_filter_function(
-                self._R_Pc, which)
+                self._R_pc, which)
 
             if which == 'fidelity':
                 self._F_pc = F_pc

--- a/filter_functions/pulse_sequence.py
+++ b/filter_functions/pulse_sequence.py
@@ -878,7 +878,7 @@ class PulseSequence:
             resulting in slower execution of the concatenation.
         """
         default_attrs = {'_HD', '_HV', '_Q'}
-        concatenation_attrs = {'_total_Q', '_total_Q_liouville', '_R', '_R_kl',
+        concatenation_attrs = {'_total_Q', '_total_Q_liouville', '_R', '_R_pc',
                                '_total_phases'}
         filter_function_attrs = {'omega', '_F', '_F_kl', '_F_pc', '_F_pc_kl'}
 
@@ -887,7 +887,7 @@ class PulseSequence:
         elif method == 'greedy':
             attrs = default_attrs.union(concatenation_attrs)
         elif method == 'frequency dependent':
-            attrs = filter_function_attrs.union({'_R', '_R_kl',
+            attrs = filter_function_attrs.union({'_R', '_R_pc',
                                                  '_total_phases'})
         else:
             attrs = filter_function_attrs.union(default_attrs,

--- a/filter_functions/pulse_sequence.py
+++ b/filter_functions/pulse_sequence.py
@@ -942,7 +942,7 @@ def _parse_args(H_c: Hamiltonian, H_n: Hamiltonian, dt: Coefficients,
     object.
     """
 
-    if not hasattr(dt, '__getitem__'):
+    if not hasattr(dt, '__len__'):
         raise TypeError('Expected a sequence of time steps, not {}'.format(
             type(dt)))
 
@@ -1016,7 +1016,7 @@ def _parse_Hamiltonian(H: Hamiltonian, n_dt: int,
         raise TypeError('Expected operators in '.format(H_str) +
                         'to be NumPy arrays or QuTiP Qobjs!')
 
-    if not all(hasattr(coeff, '__getitem__') for coeff in coeffs):
+    if not all(hasattr(coeff, '__len__') for coeff in coeffs):
         raise TypeError('Expected coefficients in '.format(H_str) +
                         'to be a sequence')
 

--- a/filter_functions/util.py
+++ b/filter_functions/util.py
@@ -70,6 +70,7 @@ Exceptions
 
 """
 import functools
+import inspect
 import io
 import json
 import operator
@@ -1096,6 +1097,36 @@ def progressbar_range(*args, show_progressbar: Optional[bool] = True,
         return progressbar(range(*args), **kwargs)
 
     return range(*args)
+
+
+def parse_optional_parameter(name: str, allowed: Sequence) -> Callable:
+    """Decorator factory to parse optional parameter with certain legal values.
+
+    If the parameter value corresponding to ``name`` (either in args or kwargs)
+    is not contained in ``allowed`` a ``ValueError`` is raised.
+    """
+    def decorator(func):
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            parameters = inspect.signature(func).parameters
+            idx = tuple(parameters).index(name)
+            try:
+                value = args[idx]
+            except IndexError:
+                value = kwargs.get(name, parameters[name].default)
+
+            if value not in allowed:
+                raise ValueError(
+                    "Invalid value for {}: {}. ".format(name, value) +
+                    "Should be one of {}.".format(allowed)
+                )
+            return func(*args, **kwargs)
+        return wrapper
+    return decorator
+
+
+parse_which_FF_parameter = parse_optional_parameter(
+    'which', ('fidelity', 'generalized'))
 
 
 class CalculationError(Exception):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -365,6 +365,16 @@ class CoreTest(testutil.TestCase):
         for attr in attrs + ['_F_kl', '_F_pc_kl']:
             self.assertIsNone(getattr(C, attr))
 
+        C.cache_filter_function(A.omega, which='fidelity')
+        C.cleanup('frequency dependent')
+        freq_attrs = {'omega', '_R', '_F', '_F_kl', '_F_pc', '_F_pc_kl',
+                      '_total_phases'}
+        for attr in freq_attrs:
+            self.assertIsNone(getattr(C, attr))
+
+        for attr in set(attrs).difference(freq_attrs):
+            self.assertIsNotNone(getattr(C, attr))
+
     def test_pulse_sequence_attributes_concat(self):
         """Test attributes of concatenated sequence."""
         X, Y, Z = ff.util.P_np[1:]

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -372,6 +372,7 @@ class CoreTest(testutil.TestCase):
                    'total phases': '_total_phases',
                    'filter function': '_F',
                    'fidelity filter function': '_F',
+                   'generalized filter function': '_F_kl',
                    'pulse correlation filter function': '_F_pc',
                    'fidelity pulse correlation filter function': '_F_pc',
                    'generalized pulse correlation filter function': '_F_pc_kl',

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -328,9 +328,9 @@ class CoreTest(testutil.TestCase):
 
         # Test cleanup
         C = ff.concatenate((A, A), calc_pulse_correlation_ff=True,
+                           which='generalized',
                            omega=ff.util.get_sample_frequencies(A))
         C.diagonalize()
-        C.cache_filter_function(ff.util.get_sample_frequencies(A))
         attrs = ['_HD', '_HV', '_Q']
         for attr in attrs:
             self.assertIsNotNone(getattr(C, attr))
@@ -340,6 +340,7 @@ class CoreTest(testutil.TestCase):
             self.assertIsNone(getattr(C, attr))
 
         C.diagonalize()
+        C.cache_control_matrix(A.omega)
         attrs.extend(['_R', '_total_phases', '_total_Q', '_total_Q_liouville'])
         for attr in attrs:
             self.assertIsNotNone(getattr(C, attr))
@@ -348,13 +349,20 @@ class CoreTest(testutil.TestCase):
         for attr in attrs:
             self.assertIsNone(getattr(C, attr))
 
-        C.cache_filter_function(ff.util.get_sample_frequencies(A))
+        C.cache_filter_function(A.omega, which='generalized')
+        for attr in attrs + ['omega', '_F_kl', '_F_pc_kl']:
+            self.assertIsNotNone(getattr(C, attr))
+
+        C = ff.concatenate((A, A), calc_pulse_correlation_ff=True,
+                           which='fidelity', omega=A.omega)
+        C.diagonalize()
+        C.cache_filter_function(A.omega, which='fidelity')
         attrs.extend(['omega', '_F', '_F_pc'])
         for attr in attrs:
             self.assertIsNotNone(getattr(C, attr))
 
         C.cleanup('all')
-        for attr in attrs:
+        for attr in attrs + ['_F_kl', '_F_pc_kl']:
             self.assertIsNone(getattr(C, attr))
 
     def test_pulse_sequence_attributes_concat(self):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -329,10 +329,10 @@ class CoreTest(testutil.TestCase):
                     setattr(A, attr, 'foo')
                     assertion = self.assertTrue
                 else:
+                    setattr(A, attr, None)
                     assertion = self.assertFalse
 
                 assertion(A.is_cached(attr))
-                setattr(A, attr, None)
 
         aliases = {'eigenvalues': '_HD',
                    'eigenvectors': '_HV',
@@ -348,7 +348,7 @@ class CoreTest(testutil.TestCase):
                    'fidelity pulse correlation filter function': '_F_pc',
                    'generalized pulse correlation filter function': '_F_pc_kl',
                    'control matrix': '_R',
-                   'pulse correlation control matrix': '_R'}
+                   'pulse correlation control matrix': '_R_pc'}
 
         for alias, attr in aliases.items():
             # set mock attribute at random
@@ -356,13 +356,14 @@ class CoreTest(testutil.TestCase):
                 setattr(A, attr, 'foo')
                 assertion = self.assertTrue
             else:
+                setattr(A, attr, None)
                 assertion = self.assertFalse
 
             assertion(A.is_cached(alias))
             assertion(A.is_cached(alias.upper()))
             assertion(A.is_cached(alias.replace(' ', '_')))
 
-            setattr(A, attr, None)
+        A.cleanup('all')
 
         # Test cleanup
         C = ff.concatenate((A, A), calc_pulse_correlation_ff=True,

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -583,3 +583,27 @@ class UtilTest(testutil.TestCase):
             ii.append(i)
 
         self.assertEqual(ii, list(range(523, 123, -32)))
+
+    def test_parse_optional_parameter(self):
+
+        @util.parse_optional_parameter('foo', [1, 'bar', (2, 3)])
+        def foobar(a, b, foo=None, x=2):
+            pass
+
+        with self.assertRaises(ValueError) as err:
+            foobar(1, 1, 2)
+            self.assertEqual(str(err.exception),
+                             "Invalid value for foo: {}.".format(2) +
+                             " Should be one of {}".format([1, 'bar', (2, 3)]))
+
+        with self.assertRaises(ValueError):
+            foobar(1, 1, 'x')
+            self.assertEqual(str(err.exception),
+                             "Invalid value for foo: {}.".format('x') +
+                             " Should be one of {}".format([1, 'bar', (2, 3)]))
+
+        with self.assertRaises(ValueError):
+            foobar(1, 1, [1, 2])
+            self.assertEqual(str(err.exception),
+                             "Invalid value for foo: {}.".format([1, 2]) +
+                             " Should be one of {}".format([1, 'bar', (2, 3)]))


### PR DESCRIPTION
Add option to compute the generalized filter functions F_{\alpha\beta, kl} instead of the canonical "fidelity" filter functions F_{\alpha\beta} = tr F_{\alpha\beta, kl} for both the regular and the pulse correlation filter function.