### PR TITLE
Adapt to pending deprecations by matplotlib and numpy

### DIFF
--- a/filter_functions/plotting.py
+++ b/filter_functions/plotting.py
@@ -755,7 +755,6 @@ def plot_error_transfer_matrix(
         grid_kw.setdefault('nrows_ncols', (n_rows, n_cols))
         grid_kw.setdefault('axes_pad', 0.3)
         grid_kw.setdefault('label_mode', 'L')
-        grid_kw.setdefault('add_all', True)
         grid_kw.setdefault('share_all', True)
         grid_kw.setdefault('direction', 'row')
         grid_kw.setdefault('cbar_mode', 'single')

--- a/filter_functions/pulse_sequence.py
+++ b/filter_functions/pulse_sequence.py
@@ -300,7 +300,7 @@ class PulseSequence:
             - basis
 
         """
-        if not isinstance(other, PulseSequence):
+        if not isinstance(other, self.__class__):
             return NotImplemented
 
         A = self

--- a/filter_functions/pulse_sequence.py
+++ b/filter_functions/pulse_sequence.py
@@ -1012,32 +1012,30 @@ def _parse_Hamiltonian(H: Hamiltonian, n_dt: int, H_str: str) -> Tuple[Sequence[
     if len(args) == 1:
         coeffs = args[0]
         identifiers = None
-    elif len(args) == 2:
-        coeffs = args[0]
-        identifiers = list(args[1])
     else:
         coeffs = args[0]
         identifiers = list(args[1])
 
-    if not all(isinstance(oper, ndarray) or hasattr(oper, 'full') for oper in opers):
-        raise TypeError(f'Expected operators in {H_str} to be NumPy arrays or QuTiP Qobjs!')
+    if any(not isinstance(oper, ndarray) for oper in opers):
+        if any(not hasattr(oper, 'full') for oper in opers):
+            raise TypeError(f'Expected operators in {H_str} to be NumPy arrays or QuTiP Qobjs!')
 
-    if not all(hasattr(coeff, '__len__') for coeff in coeffs):
-        raise TypeError(f'Expected coefficients in {H_str} to be a sequence')
-
-    # Convert qutip.Qobjs to full arrays
-    try:
-        opers = np.array([oper.full() if hasattr(oper, 'full') else oper for oper in opers])
-    except ValueError:
-        raise TypeError(f"Couldn't parse operators in {H_str}. " +
-                        "Are you sure they are all 2d arrays or qutip.Qobjs?")
+        # Convert qutip.Qobjs to full arrays
+        opers = [oper.full() if hasattr(oper, 'full') else oper for oper in opers]
+    else:
+        opers = [oper.squeeze() for oper in opers]
 
     # Check correct dimensions for the operators
     if set(oper.ndim for oper in opers) != {2}:
         raise ValueError(f'Expected all operators in {H_str} to be two-dimensional!')
 
-    if len(set(opers[0].shape)) != 1:
+    if len(set(oper.shape for oper in opers)) != 1:
         raise ValueError(f'Expected operators in {H_str} to be square!')
+
+    opers = np.asarray(opers)
+
+    if not all(hasattr(coeff, '__len__') for coeff in coeffs):
+        raise TypeError(f'Expected coefficients in {H_str} to be a sequence')
 
     # parse the identifiers
     if identifiers is None:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -81,19 +81,19 @@ class CoreTest(testutil.TestCase):
 
         with self.assertRaises(TypeError):
             # Control Hamiltonian not list or tuple
-            ff.PulseSequence(np.array(H_c), H_n, dt)
+            ff.PulseSequence(np.array(H_c, dtype=object), H_n, dt)
 
         with self.assertRaises(TypeError):
             # Noise Hamiltonian not list or tuple
-            ff.PulseSequence(H_c, np.array(H_n), dt)
+            ff.PulseSequence(H_c, np.array(H_n, dtype=object), dt)
 
         with self.assertRaises(TypeError):
             # Element of control Hamiltonian not list or tuple
-            ff.PulseSequence([np.array(H_c[0])], H_n, dt)
+            ff.PulseSequence([np.array(H_c[0], dtype=object)], H_n, dt)
 
         with self.assertRaises(TypeError):
             # Element of noise Hamiltonian not list or tuple
-            ff.PulseSequence(H_c, [np.array(H_n[0])], dt)
+            ff.PulseSequence(H_c, [np.array(H_n[0], dtype=object)], dt)
 
         idx = rng.randint(0, 3)
         with self.assertRaises(TypeError):
@@ -136,34 +136,22 @@ class CoreTest(testutil.TestCase):
             ff.PulseSequence(H_c, H_n, dt)
 
         H_n[idx][1] = coeff
-        with self.assertRaises(TypeError):
-            # Control operators weird dimensions
-            H_c[idx][0] = H_c[idx][0][:, :, None]
-            ff.PulseSequence(H_c, H_n, dt)
-
-        H_c[idx][0] = H_c[idx][0].squeeze()
-        with self.assertRaises(TypeError):
-            # Noise operators weird dimensions
-            H_n[idx][0] = H_n[idx][0][:, :, None]
-            ff.PulseSequence(H_c, H_n, dt)
-
-        H_n[idx][0] = H_n[idx][0].squeeze()
         with self.assertRaises(ValueError):
             # Control operators not 2d
             for hc in H_c:
-                hc[0] = hc[0][:, :, None]
+                hc[0] = np.tile(hc[0], (rng.randint(2, 11), 1, 1))
             ff.PulseSequence(H_c, H_n, dt)
 
         for hc in H_c:
-            hc[0] = hc[0].squeeze()
+            hc[0] = hc[0][0]
         with self.assertRaises(ValueError):
             # Noise operators not 2d
             for hn in H_n:
-                hn[0] = hn[0][:, :, None]
+                hn[0] = np.tile(hn[0], (rng.randint(2, 11), 1, 1))
             ff.PulseSequence(H_c, H_n, dt)
 
         for hn in H_n:
-            hn[0] = hn[0].squeeze()
+            hn[0] = hn[0][0]
         with self.assertRaises(ValueError):
             # Control operators not square
             for hc in H_c:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -155,19 +155,19 @@ class CoreTest(testutil.TestCase):
         with self.assertRaises(ValueError):
             # Control operators not square
             for hc in H_c:
-                hc[0] = hc[0].reshape(1, 4)
+                hc[0] = np.tile(hc[0].reshape(1, 4), (2, 1))
             ff.PulseSequence(H_c, H_n, dt)
 
         for hc in H_c:
-            hc[0] = hc[0].reshape(2, 2)
+            hc[0] = hc[0][0].reshape(2, 2)
         with self.assertRaises(ValueError):
             # Noise operators not square
             for hn in H_n:
-                hn[0] = hn[0].reshape(1, 4)
+                hn[0] = np.tile(hn[0].reshape(1, 4), (2, 1))
             ff.PulseSequence(H_c, H_n, dt)
 
         for hn in H_n:
-            hn[0] = hn[0].reshape(2, 2)
+            hn[0] = hn[0][0].reshape(2, 2)
         with self.assertRaises(ValueError):
             # Control and noise operators not same dimension
             for hn in H_n:


### PR DESCRIPTION
- `numpy`
    -  deprecating instantiating object arrays without specifying `dtype=object`
- `matplotlib`
    - deprecating the `add_all` parameter of `ImageGrid`.
    - deprecating `np.e` as default base for `SymLogNorm`. This doesn't change anything for us. The warning can be suppressed by specifying a `base` kwarg, which however has only recently introduced. Hence specifying it would impose version restrictions.