### PR TITLE
Remove negative frequencies; they're unnecessary

### DIFF
--- a/doc/source/examples/getting_started.ipynb
+++ b/doc/source/examples/getting_started.ipynb
@@ -130,10 +130,9 @@
     "\n",
     "# Generate logarithmically spaced frequencies over an interval which generally\n",
     "# captures the important regions of the filter function. Since the filter\n",
-    "# function is in this case symmetric in frequency we only need to calculate it\n",
-    "# for positive frequencies.\n",
-    "omega = ff.util.get_sample_frequencies(FID, n_samples=200, spacing='log',\n",
-    "                                       symmetric=False)\n",
+    "# function is symmetric in frequency we only need to calculate it for positive\n",
+    "# frequencies.\n",
+    "omega = ff.util.get_sample_frequencies(FID, n_samples=200, spacing='log')\n",
     "# Plot the filter function.\n",
     "fig, ax, legend = plotting.plot_filter_function(FID, omega)\n",
     "# Plot the analytic solution into the same plot\n",
@@ -259,8 +258,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "omega = ff.util.get_sample_frequencies(SE, n_samples=400, spacing='log',\n",
-    "                                       symmetric=False)\n",
+    "omega = ff.util.get_sample_frequencies(SE, n_samples=400, spacing='log')\n",
     "# Plot the filter function\n",
     "fig, ax, legend = plotting.plot_filter_function(SE, omega, yscale='log')\n",
     "ax.set_ylim(bottom=1e-13)\n",
@@ -297,7 +295,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.3"
+   "version": "3.8.5"
   }
  },
  "nbformat": 4,

--- a/doc/source/examples/qutip_integration.ipynb
+++ b/doc/source/examples/qutip_integration.ipynb
@@ -108,8 +108,7 @@
     "    *_, = plotting.plot_pulse_train(pulse, fig=fig, axes=ax[0, i])\n",
     "    ax[0, i].set_title(p_type)\n",
     "    # Plot the filter functions\n",
-    "    omega = ff.util.get_sample_frequencies(pulse, spacing='log',\n",
-    "                                           symmetric=False)\n",
+    "    omega = ff.util.get_sample_frequencies(pulse, spacing='log')\n",
     "    *_, = plotting.plot_filter_function(pulse, omega, fig=fig, axes=ax[1, i])\n",
     "    \n",
     "fig.tight_layout()"
@@ -139,9 +138,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.3"
+   "version": "3.8.5"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/filter_functions/numeric.py
+++ b/filter_functions/numeric.py
@@ -374,8 +374,7 @@ def calculate_error_vector_correlation_functions(
     spectrum: array_like, shape (..., n_omega)
         The two-sided noise power spectral density.
     omega: array_like,
-        The frequencies. Note that the frequencies are assumed to be
-        symmetric about zero.
+        The frequencies at which to calculate the filter functions.
     n_oper_identifiers: array_like, optional
         The identifiers of the noise operators for which to calculate
         the error vector correlation functions. The default is all.
@@ -638,8 +637,7 @@ def error_transfer_matrix(
         between them. n_nops is the number of noise operators considered
         and should be equal to ``len(n_oper_identifiers)``.
     omega: array_like,
-        The frequencies. Note that the frequencies are assumed to be
-        symmetric about zero.
+        The frequencies at which to calculate the filter functions.
     n_oper_identifiers: array_like, optional
         The identifiers of the noise operators for which to evaluate the
         error transfer matrix. The default is all.
@@ -822,8 +820,7 @@ def infidelity(pulse: 'PulseSequence', spectrum: Union[Coefficients, Callable],
         ('omega_IR', 'omega_UV', 'spacing', 'n_min', 'n_max',
         'n_points'), where all entries are integers except for
         ``spacing`` which should be a string, either 'linear' or 'log'.
-        'n_points' controls how many steps are taken. Note that the
-        frequencies are assumed to be symmetric about zero.
+        'n_points' controls how many steps are taken.
     n_oper_identifiers: array_like, optional
         The identifiers of the noise operators for which to calculate
         the infidelity  contribution. If given, the infidelities for
@@ -1096,8 +1093,7 @@ def _get_integrand(
     spectrum: array_like, shape (..., n_omega)
         The two-sided noise power spectral density.
     omega: array_like,
-        The frequencies. Note that the frequencies are assumed to be
-        symmetric about zero.
+        The frequencies at which to calculate the filter functions.
     idx: ndarray
         Noise operator indices to consider.
     control_matrix: ndarray, optional

--- a/filter_functions/plotting.py
+++ b/filter_functions/plotting.py
@@ -659,8 +659,6 @@ def plot_error_transfer_matrix(
         The two-sided noise spectrum.
     omega: array_like
         The frequencies for which to evaluate the error transfer matrix.
-        Note that they should be symmetric around zero, that is, include
-        negative frequencies.
     error_transfer_matrix: ndarray, shape
         A precomputed error transfer matrix. If given, *pulse*,
         *spectrum*, *omega* are not required.

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -530,48 +530,24 @@ class UtilTest(testutil.TestCase):
         )
         # Default args
         omega = util.get_sample_frequencies(pulse)
-        self.assertAlmostEqual(omega[0], -2e2*np.pi/pulse.tau)
+        self.assertAlmostEqual(omega[0], 2e-2*np.pi/pulse.tau)
         self.assertAlmostEqual(omega[-1], 2e2*np.pi/pulse.tau)
         self.assertEqual(len(omega), 300)
-        self.assertTrue((omega[:150] <= 0).all())
+        self.assertTrue((omega >= 0).all())
         self.assertLessEqual(np.var(np.diff(np.log(omega[150:]))), 1e-16)
 
         # custom args
         omega = util.get_sample_frequencies(pulse, spacing='linear',
-                                            n_samples=50, symmetric=False)
+                                            n_samples=50, include_quasistatic=True)
         self.assertAlmostEqual(omega[0], 0)
         self.assertAlmostEqual(omega[-1], 2e2*np.pi/pulse.tau)
         self.assertEqual(len(omega), 50)
         self.assertTrue((omega >= 0).all())
-        self.assertLessEqual(np.var(np.diff(omega)), 1e-16)
+        self.assertLessEqual(np.var(np.diff(omega[1:])), 1e-16)
 
         # Exceptions
         with self.assertRaises(ValueError):
             omega = util.get_sample_frequencies(pulse, spacing='foo')
-
-    def test_symmetrize_spectrum(self):
-        pulse = PulseSequence(
-            [[util.paulis[1], [np.pi/2]]],
-            [[util.paulis[1], [1]]],
-            [abs(rng.standard_normal())]
-        )
-
-        asym_omega = util.get_sample_frequencies(pulse, symmetric=False,
-                                                 n_samples=100)
-        sym_omega = util.get_sample_frequencies(pulse, symmetric=True,
-                                                n_samples=200)
-
-        S_symmetrized, omega_symmetrized = util.symmetrize_spectrum(
-            1/asym_omega**0.7, asym_omega)
-        self.assertArrayEqual(omega_symmetrized, sym_omega)
-        self.assertArrayEqual(S_symmetrized[99::-1], S_symmetrized[100:])
-        self.assertArrayEqual(S_symmetrized[100:]*2, 1/asym_omega**0.7)
-
-        # zero frequency not doubled
-        omega = np.arange(10)
-        S_sym, omega_sym = util.symmetrize_spectrum(omega, omega)
-        self.assertArrayEqual(S_sym, np.abs(np.arange(-9, 10)/2))
-        self.assertArrayEqual(omega_sym, np.arange(-9, 10))
 
     def test_progressbar_range(self):
         ii = []


### PR DESCRIPTION
Classical noise is by definition symmetric in frequency. As the real (imaginary) part of the filter function is (anti-) symmetric because the systematic time evolution is unitary, contributions from negative frequencies are exactly the same as from positive (as it should be...). 

Hence, there is no need to ever compute them.