### PR TITLE
Fix readthedocs with new pip resolver

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,9 +1,11 @@
 name: filter_functions
 
 channels:
+  - defaults
   - conda-forge
 
 dependencies:
+  - python < 3.9
   - qutip
   - pip
 


### PR DESCRIPTION
The [new dependency resolver used by pip](https://pip.pypa.io/en/latest/user_guide/#changes-to-the-pip-dependency-resolver-in-20-2-2020) broke the readthedocs build:

```
[rtd-command-info] start-time: 2020-11-17T17:27:02.448648Z, end-time: 2020-11-17T17:27:03.217538Z, duration: 0, exit-code: 2
/home/docs/checkouts/readthedocs.org/user_builds/filter-functions/conda/latest/bin/python -m pip install -U --no-cache-dir --use-feature 2020-resolver recommonmark readthedocs-sphinx-ext
Usage:   
  /home/docs/checkouts/readthedocs.org/user_builds/filter-functions/conda/latest/bin/python -m pip install [options] <requirement specifier> [package-index-options] ...
  /home/docs/checkouts/readthedocs.org/user_builds/filter-functions/conda/latest/bin/python -m pip install [options] -r <requirements file> [package-index-options] ...
  /home/docs/checkouts/readthedocs.org/user_builds/filter-functions/conda/latest/bin/python -m pip install [options] [-e] <vcs project url> ...
  /home/docs/checkouts/readthedocs.org/user_builds/filter-functions/conda/latest/bin/python -m pip install [options] [-e] <local project path> ...
  /home/docs/checkouts/readthedocs.org/user_builds/filter-functions/conda/latest/bin/python -m pip install [options] <archive url/path> ...

no such option: --use-feature
```

Somehow (most likely because `numpy` is not yet ready for Python 3.9), the command `conda install --yes --quiet --name latest mock pillow sphinx sphinx_rtd_theme` led to Python 2.7 being installed:

```
The following packages will be SUPERSEDED by a higher-priority channel:

  ca-certificates    conda-forge::ca-certificates-2020.11.~ --> pkgs/main::ca-certificates-2020.10.14-0
  certifi            conda-forge/linux-64::certifi-2020.11~ --> pkgs/main/noarch::certifi-2020.6.20-pyhd3eb1b0_3
  numpy              conda-forge::numpy-1.19.4-py39h57d35e~ --> pkgs/free::numpy-1.9.2-py27_0
  openssl            conda-forge::openssl-1.1.1h-h516909a_0 --> pkgs/main::openssl-1.1.1h-h7b6447c_0
  pip                   conda-forge/noarch::pip-20.2.4-py_0 --> pkgs/main/linux-64::pip-19.3.1-py27_0
  python             conda-forge::python-3.9.0-h2a148a8_4_~ --> pkgs/main::python-2.7.18-h02575d3_0
  scipy              conda-forge::scipy-1.5.3-py39hee8e79c~ --> pkgs/free::scipy-0.16.0-np19py27_0
  setuptools         conda-forge::setuptools-49.6.0-py39h0~ --> pkgs/main::setuptools-44.0.0-py27_0
```

Pinning `python < 3.9` in the conda environment seems to fix the issue for now.