### PR TITLE
More informative error messages

### DIFF
--- a/filter_functions/pulse_sequence.py
+++ b/filter_functions/pulse_sequence.py
@@ -2250,7 +2250,8 @@ def extend(
             raise ValueError(f'Expected additional noise operators to have dimensions {(d, d)}, ' +
                              f'not {add_n_opers.shape[1:]}.')
         if any(n_oper_id in n_oper_identifiers for n_oper_id in add_n_oper_id):
-            raise ValueError('Found duplicate noise operator identifiers')
+            identifiers = set(n_oper_identifiers).intersection(add_n_oper_id)
+            raise ValueError(f'Found duplicate noise operator identifiers: {identifiers}')
 
         n_opers.extend(add_n_opers)
         n_coeffs.extend(add_n_coeffs)


### PR DESCRIPTION
Tell user offending intersecting noise oper identifiers in `pulse_sequence.extend()`