### PR TITLE
Hotfix gradient with cache intermediates

### DIFF
--- a/filter_functions/__init__.py
+++ b/filter_functions/__init__.py
@@ -20,7 +20,7 @@
 # =============================================================================
 """Package for efficient calculation of generalized filter functions"""
 
-from . import analytic, basis, numeric, pulse_sequence, superoperator, util
+from . import analytic, basis, gradient, numeric, pulse_sequence, superoperator, util
 from .basis import Basis
 from .gradient import infidelity_derivative
 from .numeric import error_transfer_matrix, infidelity
@@ -29,7 +29,7 @@ from .superoperator import liouville_representation
 
 __all__ = ['Basis', 'PulseSequence', 'analytic', 'basis', 'concatenate', 'concatenate_periodic',
            'error_transfer_matrix', 'extend', 'infidelity', 'liouville_representation', 'numeric',
-           'pulse_sequence', 'remap', 'util', 'superoperator', 'infidelity_derivative']
+           'gradient', 'pulse_sequence', 'remap', 'util', 'superoperator', 'infidelity_derivative']
 
 
 __version__ = '1.0.1'

--- a/filter_functions/__init__.py
+++ b/filter_functions/__init__.py
@@ -32,6 +32,6 @@ __all__ = ['Basis', 'PulseSequence', 'analytic', 'basis', 'concatenate', 'concat
            'gradient', 'pulse_sequence', 'remap', 'util', 'superoperator', 'infidelity_derivative']
 
 
-__version__ = '1.0.1'
+__version__ = '1.0.2'
 __license__ = 'GNU GPLv3+'
 __author__ = 'Quantum Technology Group, RWTH Aachen University'

--- a/filter_functions/gradient.py
+++ b/filter_functions/gradient.py
@@ -487,7 +487,8 @@ def calculate_derivative_of_control_matrix_from_scratch(
     basis_transformed = numeric._transform_by_unitary(eigvecs[:, None], basis[None],
                                                       out=np.empty((n_dt, d**2, d, d), complex))
     c_opers_transformed = numeric._transform_hamiltonian(eigvecs, c_opers[idx]).swapaxes(0, 1)
-    if intermediates is None:
+    if not intermediates:
+        # None or empty
         n_opers_transformed = numeric._transform_hamiltonian(eigvecs, n_opers,
                                                              n_coeffs).swapaxes(0, 1)
         exp_buf, integral = np.empty((2, n_omega, d, d), dtype=complex)
@@ -507,7 +508,7 @@ def calculate_derivative_of_control_matrix_from_scratch(
                                           n_opers.shape, (len(omega), d, d),
                                           optimize=[(0, 3), (0, 1), (0, 1)])
     for g in range(n_dt):
-        if intermediates is None:
+        if not intermediates:
             integral = numeric._first_order_integral(omega, eigvals[g], dt[g], exp_buf, integral)
         else:
             integral = intermediates['first_order_integral'][g]


### PR DESCRIPTION
If calling `infidelity` and then `infidelity_derivative`, the control matrix is cached during the first call, but not the intermediates. This leads to an exception when `gradient.calculate_control_matrix_derivative_from_scratch()` tries to access the intermediates (since `PulseSequence.get_filter_function_derivative()` passes them along).