### PR TITLE
Remove Python 3.6 support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python_version: [3.6, 3.7, 3.8, 3.9]
+        python_version: [3.7, 3.8, 3.9]
         install_extras: ['tests', 'plotting,fancy_progressbar,tests', 'plotting,bloch_sphere_visualization,fancy_progressbar,doc,tests']
 
     steps:

--- a/setup.py
+++ b/setup.py
@@ -18,8 +18,8 @@ def extract_version(version_file):
     raise RuntimeError("Unable to find version string.")
 
 
-if sys.version_info < (3, 6):
-    sys.stderr.write('ERROR: You need Python 3.6 or later to install this package.\n')
+if sys.version_info < (3, 7):
+    sys.stderr.write('ERROR: You need Python 3.7 or later to install this package.\n')
     exit(1)
 
 extras_require = {'plotting': ['matplotlib'],


### PR DESCRIPTION
Version ``3.6`` is end-of-life since [2021-12-23](https://www.python.org/dev/peps/pep-0494/#lifespan).