### PR TITLE
n_coeffs_deriv sorting

### DIFF
--- a/filter_functions/gradient.py
+++ b/filter_functions/gradient.py
@@ -262,7 +262,7 @@ def _control_matrix_at_timestep_derivative(
         The individual control matrices of all time steps
     ctrlmat_g_deriv: ndarray, shape (n_dt, n_nops, d**2, n_ctrl, n_omega)
         The corresponding derivative with respect to the control
-        strength :math:`\frac{\partial\mathcal{B}_{\alpha j}^{(g)}(\omega)}
+        strength :math:`\frac{\partial\mathcal{B}_{\alpha j}^{(g)}(\omega)}`
 
     Notes
     -----
@@ -613,7 +613,9 @@ def infidelity_derivative(
     infid_deriv: ndarray, shape (n_nops, n_dt, n_ctrl)
         Array with the derivative of the infidelity for each noise
         source taken for each control direction at each time step
-        :math:`\frac{\partial I_e}{\partial u_h(t_{g'})}`.
+        :math:`\frac{\partial I_e}{\partial u_h(t_{g'})}`. Sorted in
+        the same fashion as `n_coeffs_deriv` or, if not given,
+        alphanumerically by the identifiers.
 
     Notes
     -----

--- a/filter_functions/gradient.py
+++ b/filter_functions/gradient.py
@@ -553,6 +553,7 @@ def infidelity_derivative(
         spectrum: Coefficients,
         omega: Coefficients,
         control_identifiers: Optional[Sequence[str]] = None,
+        n_oper_identifiers: Optional[Sequence[str]] = None,
         n_coeffs_deriv: Optional[Sequence[Coefficients]] = None
 ) -> ndarray:
     r"""Calculate the entanglement infidelity derivative of the
@@ -577,11 +578,29 @@ def infidelity_derivative(
     omega: array_like, shape (n_omega,)
         The frequencies at which the integration is to be carried out.
     control_identifiers: Sequence[str], shape (n_ctrl,)
-        Sequence of strings with the control identifiern to distinguish
-        between accessible control and drift Hamiltonian.
+        Sequence of strings with the control identifiers to
+        distinguish between control and drift Hamiltonian. The
+        default is None, in which case the derivative is computed
+        for all known non-noise operators.
+    n_oper_identifiers: Sequence[str], shape (n_nops,)
+        Sequence of strings with the noise identifiers for which to
+        compute the derivative contribution. The default is None, in
+        which case it is computed for all known noise operators.
     n_coeffs_deriv: array_like, shape (n_nops, n_ctrl, n_dt)
         The derivatives of the noise susceptibilities by the control
-        amplitudes. Defaults to None.
+        amplitudes. The rows and columns should be in the same order
+        as the corresponding identifiers above. Defaults to None, in
+        which case the coefficients are assumed to be constant and
+        hence their derivative vanishing.
+
+        .. warning::
+
+            Internally, control and noise terms of the Hamiltonian
+            are stored alphanumerically sorted by their identifiers.
+            If the noise and/or control identifiers above are not
+            explicitly given, the rows and/or columns of this
+            parameter need to be sorted in the same fashion.
+
 
     Raises
     ------
@@ -636,7 +655,9 @@ def infidelity_derivative(
         https://doi.org/10.1016/S0375-9601(02)01272-0
     """
     spectrum = numeric._parse_spectrum(spectrum, omega, range(len(pulse.n_opers)))
-    filter_function_deriv = pulse.get_filter_function_derivative(omega, control_identifiers,
+    filter_function_deriv = pulse.get_filter_function_derivative(omega,
+                                                                 control_identifiers,
+                                                                 n_oper_identifiers,
                                                                  n_coeffs_deriv)
 
     integrand = np.einsum('ao,atho->atho', spectrum, filter_function_deriv)

--- a/tests/gradient_testutil.py
+++ b/tests/gradient_testutil.py
@@ -21,10 +21,6 @@ def deriv_exchange_interaction(eps):
     return j_0 / eps_0 * np.exp(eps / eps_0)
 
 
-def deriv_2_exchange_interaction(eps):
-    return j_0 / eps_0 ** 2 * np.exp(eps / eps_0)
-
-
 def one_over_f_noise(f):
     spectrum = np.divide(S_0, f, where=(f != 0))
     spectrum[f == 0] = spectrum[np.abs(f).argmin()]
@@ -40,8 +36,6 @@ def create_sing_trip_pulse_seq(eps, dbz, *args):
 
     H_n = [
         [sigma_z, deriv_exchange_interaction(eps[0])]
-        # [sigma_z, np.ones_like(eps[0])]
-
     ]
 
     dt = time_step * np.ones(n_time_steps)

--- a/tests/gradient_testutil.py
+++ b/tests/gradient_testutil.py
@@ -84,18 +84,17 @@ def finite_diff_infid(u_ctrl_central, u_drift, d, pulse_sequence_builder,
 
     """
     pulse = pulse_sequence_builder(u_ctrl_central, u_drift, d)
-    all_id = pulse.c_oper_identifiers
     if c_id is None:
-        c_id = all_id[:len(u_ctrl_central)]
+        c_id = pulse.c_oper_identifiers[:len(u_ctrl_central)]
 
     # Make sure we test for zero frequency case (possible convergence issues)
     omega = ff.util.get_sample_frequencies(pulse=pulse, n_samples=n_freq_samples, spacing='log',
                                            include_quasistatic=True)
     spectrum = spectral_noise_density(omega)
 
-    gradient = np.empty((len(pulse.n_coeffs), len(pulse.dt), len(c_id)))
+    gradient = np.empty(pulse.n_coeffs.shape + (len(c_id),))
 
-    for g in range(len(pulse.dt)):
+    for g in range(len(pulse)):
         for k in range(len(c_id)):
             u_plus = u_ctrl_central.copy()
             u_plus[k, g] += delta_u

--- a/tests/test_gradient.py
+++ b/tests/test_gradient.py
@@ -32,7 +32,8 @@ class GradientTest(testutil.TestCase):
 
         initial_pulse = testutil.rng.uniform(size=(1, gradient_testutil.n_time_steps))
         u_drift = np.full(gradient_testutil.n_time_steps, testutil.rng.standard_normal())
-        n_coeffs_deriv = gradient_testutil.deriv_2_exchange_interaction(eps=initial_pulse)[None]
+        # dJ/dJ = 1
+        n_coeffs_deriv = np.ones((1, 1, gradient_testutil.n_time_steps))
 
         fin_diff_grad = gradient_testutil.finite_diff_infid(
             u_ctrl_central=initial_pulse, u_drift=u_drift, d=2,


### PR DESCRIPTION
Internally operators are sorted by their identifiers, but there were no checks performed in `PulseSequence.get_filter_function_derivative` whether the `n_coeffs_deriv` parameter is sorted as such.